### PR TITLE
Fix that unable to restart server after Mojo::WebQQ actively stopped running

### DIFF
--- a/server/node/mojo-webqq.js
+++ b/server/node/mojo-webqq.js
@@ -1,5 +1,7 @@
 var spawn = require('child_process').spawn;
 var path = require('path');
+var fs = require('fs');
+const os = require('os');
 
 function MojoQQ(port, openqq_port) {
     this.proc = null;
@@ -7,7 +9,7 @@ function MojoQQ(port, openqq_port) {
     this.openqq_port = openqq_port;
 
     this.restart = function() {
-        if (this.proc === null || this.proc.killed) {
+        if (this.proc === null || this.proc.killed || !fs.existsSync(os.tmpdir()+'/mojo_webqq_pid_ffm.pid')) {
             console.log("[FFM] starting Mojo-Webqq...");
 
             var cmd = 'perl';

--- a/server/perl/start.pl
+++ b/server/perl/start.pl
@@ -13,7 +13,8 @@ GetOptions(
 
 my $client = Mojo::Webqq->new(
     log_encoding           => 'utf8',
-    poll_failure_count_max => 20
+    poll_failure_count_max => 20,
+    account => 'ffm'
 );
 
 $client->load('UploadQRcode');


### PR DESCRIPTION
Please notice that this fix is just a hack and heavily relys on Mojo::WebQQ pid. A better fix is needed to deal with this issue.
可能是因为proc不会因为子进程挂了而变成null，因此需要另外的方法判断进程存活